### PR TITLE
Replace .jekyllignore with _config.yml exclude

### DIFF
--- a/.jekyllignore
+++ b/.jekyllignore
@@ -1,3 +1,0 @@
-rpm-stubs/
-hack/
-templates/

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+# Directories excluded from the Jekyll build and GitHub Pages deployment.
+exclude:
+  - rpm-stubs
+  - hack
+  - templates


### PR DESCRIPTION
The exclude directive in _config.yml is the correct mechanism to prevent directories from appearing in the Jekyll build output.