### PR TITLE
Fix git add pathspec failure in update-rpm-repo workflow

### DIFF
--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -159,8 +159,7 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          # Stage stubs, manifests, repodata, and HTML — never commit full RPM binaries
-          git add '*.rpm' '*/rpm-manifest.json' '*/repodata/' '*.html' '*.repo'
+          git add -A
 
           if git diff --staged --quiet; then
             echo "[INFO] No changes detected"


### PR DESCRIPTION
The `*/repodata/` glob only matches one directory level, but repodata lives at paths like epel/9/x86_64/repodata/ (three levels deep). Replace the fragile multi-pathspec git add with `git add -A` — full RPM binaries are already deleted before this step and .output/ is gitignored.