### PR TITLE
Fix regenerate-rpm-repo skipping new distro versions

### DIFF
--- a/hack/regenerate-rpm-repo.py
+++ b/hack/regenerate-rpm-repo.py
@@ -65,9 +65,7 @@ def find_stubs_dirs(repo_root: Path) -> list[tuple[Path, Path]]:
             continue
         rel = stubs_dir.relative_to(stubs_root)
         arch_dir = repo_root / rel
-        if not (arch_dir / "repodata").exists():
-            print(f"[WARN] No repodata dir for {rel}, skipping.")
-            continue
+        arch_dir.mkdir(parents=True, exist_ok=True)
         pairs.append((stubs_dir, arch_dir))
     return pairs
 


### PR DESCRIPTION
New distro versions (e.g. fedora/44) were silently skipped because find_stubs_dirs() required the target arch directory and its repodata/ subdirectory to already exist. Replace the skip with mkdir so new distro version directories are created on the fly.

Assisted-by: Claude <noreply@anthropic.com>