### PR TITLE
Filter by package name when searching for flightctl COPR build

### DIFF
--- a/hack/copr-to-gh_pages-download.sh
+++ b/hack/copr-to-gh_pages-download.sh
@@ -155,7 +155,7 @@ main() {
 
     # Find the build
     local build_id
-    if ! build_id=$(find_copr_build "$version"); then
+    if ! build_id=$(find_copr_build "$version" "flightctl"); then
         error "Failed to find build for version $version"
         exit 1
     fi


### PR DESCRIPTION
find_copr_build was called without a package name filter for the main flightctl lookup, so it matched the first build with the right version regardless of package. When flightctl-onboarding had a higher build ID, it was returned instead, causing only onboarding RPMs to be downloaded.

Assisted-by: Claude <noreply@anthropic.com>